### PR TITLE
#166108964 admin query loans using their status: accepted/pending

### DIFF
--- a/server/controllers/Loans.js
+++ b/server/controllers/Loans.js
@@ -30,6 +30,21 @@ class Loans {
 			reqResponses.handleError(500, error.toString(), res);
 		}
 	}
+
+	static async loanRepaidstatus(req, res) {
+		try {
+			const { status,repaid } = req.query;
+			const loanstatus = await Models.loanRepaidstatus(status, repaid);
+			if (!loanstatus) {
+				return reqResponses.handleError(404, 'No loans records found', res);
+			}
+			reqResponses.handleSuccess(200, 'loan status', loanstatus.result, res);
+		} catch (error) {
+			console.log(error);
+			reqResponses.handleError(500, error.toString(), res);
+		}
+	}
+
 	
 }
 

--- a/server/models/Loans.js
+++ b/server/models/Loans.js
@@ -20,6 +20,7 @@ class LoanModel {
     const sqlInsert = 'INSERT INTO loans (usermail,firstname,lastname, requestedOn, status, repaid, tenor, principalAmount, paymentInstallment, totalAmounttopay, intrestRate) VALUES($1, $2, $3, $4, $5 ,$6 ,$7 ,$8 ,$9, $10, $11)  returning *;';
     const values = [email, firstname, lastname, dateRequested, 'pending', false, calculateTotalamount.tenor, amount, calculateTotalamount.installmentAmount, calculateTotalamount.totalamounttoPay, calculateTotalamount.interestRate];
     const {rows} = await Db.query(sqlInsert, values);
+    console.log(rows);
     this.result = rows;
     return true;
   }
@@ -32,6 +33,22 @@ class LoanModel {
     }
     const result = rows[0];
     return result;
+  }
+
+  static async loanRepaidstatus(status, repaid) {    
+    let repaidStatus;
+    if (repaid === 'false') {
+      repaidStatus = false;
+    } else if (repaid === 'true') {
+      repaidStatus = true;
+    }
+    const sql = `SELECT * FROM loans WHERE status ='${status}' AND repaid = '${repaidStatus}'`;
+    const { rows } = await Db.query(sql);
+    if (rows.length === 0) {
+      return false;
+    }
+    this.result =  rows;
+    return true;
   }
 
 }

--- a/server/routes/loans.js
+++ b/server/routes/loans.js
@@ -6,5 +6,6 @@ import checkAuth from '../middleware/auth';
 const route = express.Router();
 
 route.post('/requestloan', checkAuth.checkUser, validation.validateLoan, validation.validateexistingloanrequest, loans.requestLoan);
+route.get('/loans', checkAuth.checkAdmin, loans.loanRepaidstatus);
 
 export default route;

--- a/server/test/loans.test.js
+++ b/server/test/loans.test.js
@@ -24,6 +24,7 @@ describe('/LOAN', () => {
       firstname: 'main',
       lastname: 'admin',
       address: 'database',
+      isAdmin: true
     },
     process.env.JWT_KEY, {
       expiresIn: '1h',
@@ -34,6 +35,7 @@ describe('/LOAN', () => {
       firstname: 'Joseph',
       lastname: 'Njuguna',
       address: 'Kenya',
+      isAdmin: false
     },
     process.env.JWT_KEY, {
       expiresIn: '1h',
@@ -109,11 +111,25 @@ describe('/LOAN', () => {
     });
 
   });
+  
   describe('/CALCULATE TOTAL AMOUNT',(done)=>{
     it('should calculate the Total amount payable when user enters loan request', () => {
       assert.equal(2100, total.totalAmountdata(2000,4).totalamounttoPay);
       expect(total.totalAmountdata(2000,5)).to.be.an('Object');
     });
   });
-  
+
+  describe('/GET admin get loans by their status', (done)=>{
+    it('should get all loans fully paid', (done) => {
+      chai.request(app)
+        .get('/api/v2/loans?status=pending&repaid=false')
+        .set('authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          if (err) return done();
+          done();
+        });
+    });
+  })
+
 })


### PR DESCRIPTION
### What does this PR do?
- [ ] adds a function to enable admin view loans based on their status.
### Description of the task to be completed?
- [ ] enable admin query loans from the database using different status: **`accepted/rejected/pending`**
### How should this be manually tested?
- [ ] clone the repo to your machine ``. 
- [ ] open the cloned repo using your terminal.
- [ ] run `npm install` to install all dependencies.
- [ ] run `npm test` to test the api endpoint.**test should pass**
- [ ] run `npm start` to test on postman with api endpoint `/api/v2/loans?status=pending&repaid=false` **GET**

### Any background context you want to provide?
- [ ] ----none---
### Relevant pivotal tracker stories?

- [ ] [ #166108964 ](https://www.pivotaltracker.com/story/show/166108964)
